### PR TITLE
SYS-338: add is alive and is healthy endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ The log server can be started using:
 npm run log_server
 ```
 
+### Health Check
+
+GET `/is-alive` this endpoint returns 200 if the server is running.
+GET `/is-healthy` currently the same as `/is-alive` but will be expanded.
+
 ## Contributing
 
 Contributions are highly encouraged! We welcome everyone to participate in our codebases, issue trackers, and any other form of communication. However, we expect all contributors to adhere to our [code of conduct](./CODE_OF_CONDUCT.md) to ensure a positive and collaborative environment for all involved in the project.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ npm run log_server
 
 ### Health Check
 
-GET `/is-alive` this endpoint returns 200 if the server is running.
-GET `/is-healthy` currently the same as `/is-alive` but will be expanded.
+- GET `/is-alive` this endpoint returns 200 if the server is running.
+- GET `/is-healthy` currently the same as `/is-alive` but will be expanded.
 
 ## Contributing
 

--- a/src/routes/healthCheck.ts
+++ b/src/routes/healthCheck.ts
@@ -1,0 +1,14 @@
+import { FastifyPluginCallback } from 'fastify'
+
+export const healthCheckRouter: FastifyPluginCallback = function (fastify, opts, done) {
+  fastify.get('/is-alive', (req, res) => {
+    return res.status(200).send('OK')
+  })
+
+  fastify.get('/is-healthy', (req, res) => {
+    // TODO: Add actual health check logic
+    return res.status(200).send('OK')
+  })
+  
+  done()
+}

--- a/src/routes/healthCheck.ts
+++ b/src/routes/healthCheck.ts
@@ -9,6 +9,6 @@ export const healthCheckRouter: FastifyPluginCallback = function (fastify, opts,
     // TODO: Add actual health check logic
     return res.status(200).send('OK')
   })
-  
+
   done()
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,7 @@ import path from 'path'
 import fs from 'fs'
 import { registerCache } from './cache/LatestBlockCache'
 import { Utils as StringUtils } from '@shardus/types'
+import { healthCheckRouter } from './routes/healthCheck'
 
 if (config.env == envEnum.DEV) {
   //default debug mode keys
@@ -137,6 +138,7 @@ const start = async (): Promise<void> => {
     timeWindow: '1 minute',
     allowList: ['127.0.0.1', 'localhost'],
   })
+  await server.register(healthCheckRouter)
   server.addContentTypeParser('application/json', { parseAs: 'string' }, (req, body, done) => {
     try {
       const jsonString = typeof body === 'string' ? body : body.toString('utf8')


### PR DESCRIPTION
This pull request adds two new endpoints, `/is-alive` and `/is-healthy`, to the existing API. The `/is-alive` endpoint returns a 200 status code if the server is running, while the `/is-healthy` endpoint will be expanded in the future.
- adds `/is-alive`
- adds `/is-healthy`