### PR TITLE
SHARD-2153: Ensure blocks older than a minute are emitted

### DIFF
--- a/src/log_subscription/CollectorSocketconnection.ts
+++ b/src/log_subscription/CollectorSocketconnection.ts
@@ -56,7 +56,7 @@ const pendingBlocksQueue: { blockData: any; timestamp: number }[] = []
 // Function to process the pending blocks queue
 const processPendingBlocks = (): void => {
   const currentTime = Date.now()
-  const oneMinuteAgo = currentTime - 60000 // 60 seconds * 1000 ms
+  const oneMinuteAgo = currentTime - CONFIG.blockIndexing.cycleDurationInSeconds * 1000 // 60 seconds * 1000 ms
 
   // Process blocks that are now at least a minute old
   while (pendingBlocksQueue.length > 0 && pendingBlocksQueue[0].timestamp <= oneMinuteAgo) {
@@ -71,7 +71,7 @@ const processPendingBlocks = (): void => {
   // Schedule next check if there are still pending blocks
   if (pendingBlocksQueue.length > 0) {
     const nextBlockTime = pendingBlocksQueue[0].timestamp
-    const timeToWait = Math.max(nextBlockTime + 60000 - currentTime, 1000) // At least wait 1 second
+    const timeToWait = Math.max(nextBlockTime + CONFIG.blockIndexing.cycleDurationInSeconds * 1000 - currentTime, 1000) // At least wait 1 second
     setTimeout(processPendingBlocks, timeToWait)
   }
 }
@@ -79,7 +79,7 @@ const processPendingBlocks = (): void => {
 export const forwardBlockData = async (blockData: any): Promise<void> => {
   const blockTimestamp = parseInt(blockData.header.timestamp, 16) * 1000 // Convert hex timestamp to milliseconds
   const currentTime = Date.now()
-  const oneMinuteAgo = currentTime - 60000 // 60 seconds * 1000 ms
+  const oneMinuteAgo = currentTime - CONFIG.blockIndexing.cycleDurationInSeconds * 1000 // 60 seconds * 1000 ms
 
   if (blockTimestamp <= oneMinuteAgo) {
     // Block is already a minute old, emit immediately
@@ -96,7 +96,10 @@ export const forwardBlockData = async (blockData: any): Promise<void> => {
 
     // If this is the first block in the queue, start the processing timer
     if (pendingBlocksQueue.length === 1) {
-      const timeToWait = Math.max(blockTimestamp + 60000 - currentTime, 1000) // At least wait 1 second
+      const timeToWait = Math.max(
+        blockTimestamp + CONFIG.blockIndexing.cycleDurationInSeconds * 1000 - currentTime,
+        1000
+      ) // At least wait 1 second
       setTimeout(processPendingBlocks, timeToWait)
     }
   }

--- a/src/log_subscription/CollectorSocketconnection.ts
+++ b/src/log_subscription/CollectorSocketconnection.ts
@@ -56,10 +56,10 @@ const pendingBlocksQueue: { blockData: any; timestamp: number }[] = []
 // Function to process the pending blocks queue
 const processPendingBlocks = (): void => {
   const currentTime = Date.now()
-  const oneMinuteAgo = currentTime - CONFIG.blockIndexing.cycleDurationInSeconds * 1000 // 60 seconds * 1000 ms
+  const oneCycleDurationAgo = currentTime - CONFIG.blockIndexing.cycleDurationInSeconds * 1000 // 60 seconds * 1000 ms
 
   // Process blocks that are now at least a minute old
-  while (pendingBlocksQueue.length > 0 && pendingBlocksQueue[0].timestamp <= oneMinuteAgo) {
+  while (pendingBlocksQueue.length > 0 && pendingBlocksQueue[0].timestamp <= oneCycleDurationAgo) {
     const { blockData } = pendingBlocksQueue.shift()!
 
     for (const socket of registeredLogServers.values()) {
@@ -79,9 +79,9 @@ const processPendingBlocks = (): void => {
 export const forwardBlockData = async (blockData: any): Promise<void> => {
   const blockTimestamp = parseInt(blockData.header.timestamp, 16) * 1000 // Convert hex timestamp to milliseconds
   const currentTime = Date.now()
-  const oneMinuteAgo = currentTime - CONFIG.blockIndexing.cycleDurationInSeconds * 1000 // 60 seconds * 1000 ms
+  const oneCycleDurationAgo = currentTime - CONFIG.blockIndexing.cycleDurationInSeconds * 1000 // 60 seconds * 1000 ms
 
-  if (blockTimestamp <= oneMinuteAgo) {
+  if (blockTimestamp <= oneCycleDurationAgo) {
     // Block is already a minute old, emit immediately
     for (const socket of registeredLogServers.values()) {
       socket.emit(BlockDataWsEvent, StringUtils.safeStringify(blockData))

--- a/src/log_subscription/CollectorSocketconnection.ts
+++ b/src/log_subscription/CollectorSocketconnection.ts
@@ -50,9 +50,54 @@ export const forwardReceiptData = async (data: Receipt[]): Promise<void> => {
   /* prettier-ignore */ if (CONFIG.verbose) console.log(`Forwarded receipt data to ${registeredLogServers.size} LogServers`)
 }
 
-export const forwardBlockData = async (blockData: any): Promise<void> => {
-  for (const socket of registeredLogServers.values()) {
-    socket.emit(BlockDataWsEvent, StringUtils.safeStringify(blockData))
+// Queue to store blocks that are less than a minute old
+const pendingBlocksQueue: { blockData: any; timestamp: number }[] = []
+
+// Function to process the pending blocks queue
+const processPendingBlocks = (): void => {
+  const currentTime = Date.now()
+  const oneMinuteAgo = currentTime - 60000 // 60 seconds * 1000 ms
+
+  // Process blocks that are now at least a minute old
+  while (pendingBlocksQueue.length > 0 && pendingBlocksQueue[0].timestamp <= oneMinuteAgo) {
+    const { blockData } = pendingBlocksQueue.shift()!
+
+    for (const socket of registeredLogServers.values()) {
+      socket.emit(BlockDataWsEvent, StringUtils.safeStringify(blockData))
+    }
+    /* prettier-ignore */ if (CONFIG.verbose) console.log(`Forwarded queued block data to ${registeredLogServers.size} LogServers`);
   }
-  /* prettier-ignore */ if (CONFIG.verbose) console.log(`Forwarded block data to ${registeredLogServers.size} LogServers`)
+
+  // Schedule next check if there are still pending blocks
+  if (pendingBlocksQueue.length > 0) {
+    const nextBlockTime = pendingBlocksQueue[0].timestamp
+    const timeToWait = Math.max(nextBlockTime + 60000 - currentTime, 1000) // At least wait 1 second
+    setTimeout(processPendingBlocks, timeToWait)
+  }
+}
+
+export const forwardBlockData = async (blockData: any): Promise<void> => {
+  const blockTimestamp = parseInt(blockData.header.timestamp, 16) * 1000 // Convert hex timestamp to milliseconds
+  const currentTime = Date.now()
+  const oneMinuteAgo = currentTime - 60000 // 60 seconds * 1000 ms
+
+  if (blockTimestamp <= oneMinuteAgo) {
+    // Block is already a minute old, emit immediately
+    for (const socket of registeredLogServers.values()) {
+      socket.emit(BlockDataWsEvent, StringUtils.safeStringify(blockData))
+    }
+    /* prettier-ignore */ if (CONFIG.verbose) console.log(`Forwarded block data to ${registeredLogServers.size} LogServers`);
+  } else {
+    // Add to pending queue
+    pendingBlocksQueue.push({ blockData, timestamp: blockTimestamp })
+    pendingBlocksQueue.sort((a, b) => a.timestamp - b.timestamp) // Ensure queue is sorted by timestamp
+
+    /* prettier-ignore */ if (CONFIG.verbose) console.log(`Queued block data: block timestamp ${new Date(blockTimestamp).toISOString()} is less than a minute old`);
+
+    // If this is the first block in the queue, start the processing timer
+    if (pendingBlocksQueue.length === 1) {
+      const timeToWait = Math.max(blockTimestamp + 60000 - currentTime, 1000) // At least wait 1 second
+      setTimeout(processPendingBlocks, timeToWait)
+    }
+  }
 }


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Implement queue for blocks less than a minute old.

- Emit blocks immediately if older than a minute.

- Schedule processing for queued blocks.

- Ensure blocks are processed in timestamp order.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CollectorSocketconnection.ts</strong><dd><code>Implement queue and processing for block data emission</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/log_subscription/CollectorSocketconnection.ts

<li>Added a queue for blocks less than a minute old.<br> <li> Implemented function to process and emit queued blocks.<br> <li> Modified block data emission logic to handle new queue.<br> <li> Ensured blocks are emitted in correct timestamp order.


</details>


  </td>
  <td><a href="https://github.com/shardeum/collector/pull/74/files#diff-4b83922bc050dfc15face8527d0a3b0d574209402afbb619706a08a56a48cf71">+48/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>