### PR TITLE
Latest behind by seconds default

### DIFF
--- a/src/class/validateData.ts
+++ b/src/class/validateData.ts
@@ -61,11 +61,7 @@ export async function validateData(data: Data): Promise<boolean> {
     await insertOrUpdateCycle(data.cycle)
 
     // Send blocks from previous cycle
-    await upsertBlocksForCycleCore(
-      data.cycle.counter + 1,
-      data.cycle.cycleRecord.start - CONFIG.blockIndexing.cycleDurationInSeconds,
-      true
-    )
+    await upsertBlocksForCycleCore(data.cycle.counter + 1, data.cycle.cycleRecord.start, true)
     return true
   }
   if (data.originalTx) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -129,7 +129,7 @@ let config: Config = {
     blockProductionRate: 6,
     initBlockNumber: 0,
     cycleDurationInSeconds: 60,
-    latestBehindBySeconds: 10,
+    latestBehindBySeconds: 120,
   },
   blockCache: {
     enabled: false,


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Set `latestBehindBySeconds` default to 120 seconds.

- Fix optimistic insert to use cycle plus duration.

- Remove unnecessary cycle duration subtraction in `validateData`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validateData.ts</strong><dd><code>Simplify cycle duration logic in `validateData`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/class/validateData.ts

<li>Removed subtraction of cycle duration in <code>upsertBlocksForCycleCore</code>.<br> <li> Simplified function call parameters.


</details>


  </td>
  <td><a href="https://github.com/shardeum/collector/pull/77/files#diff-fa1d8eaad534df13f9892ac2a251df18879c15c8ca91c88e85e4095b5e18019d">+1/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Update default `latestBehindBySeconds` value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config/index.ts

- Changed `latestBehindBySeconds` from 10 to 120.


</details>


  </td>
  <td><a href="https://github.com/shardeum/collector/pull/77/files#diff-198a1431d7c5e26ea78bc6e54b34b54e6f8ab342dd48ea11013877e8466a87c5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>