### PR TITLE
SHARD-2547: add flag to determine if receipts should be saved with or without sig…

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -74,6 +74,7 @@ export interface Config {
   saveAccountHistoryState: boolean
   collectorMode: string
   storeReceiptBeforeStates: boolean
+  saveReceiptsWithSignaturePacks: boolean
   checkpointWindow: number
   chainId: string
 }
@@ -138,6 +139,7 @@ let config: Config = {
   saveAccountHistoryState: true,
   collectorMode: process.env.COLLECTOR_MODE || collectorMode.WS.toString(),
   storeReceiptBeforeStates: true,
+  saveReceiptsWithSignaturePacks: Boolean(process.env.SAVE_RECEIPTS_WITH_SIGNATURE_PACKS) || true,
   checkpointWindow: 21,
   chainId: process.env.CHAIN_ID || '8082',
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -139,7 +139,7 @@ let config: Config = {
   saveAccountHistoryState: true,
   collectorMode: process.env.COLLECTOR_MODE || collectorMode.WS.toString(),
   storeReceiptBeforeStates: true,
-  saveReceiptsWithSignaturePacks: Boolean(process.env.SAVE_RECEIPTS_WITH_SIGNATURE_PACKS) || true,
+  saveReceiptsWithSignaturePacks: process.env.SAVE_RECEIPTS_WITH_SIGNATURE_PACKS !== undefined ? Boolean(process.env.SAVE_RECEIPTS_WITH_SIGNATURE_PACKS) : true,
   checkpointWindow: 21,
   chainId: process.env.CHAIN_ID || '8082',
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -139,7 +139,10 @@ let config: Config = {
   saveAccountHistoryState: true,
   collectorMode: process.env.COLLECTOR_MODE || collectorMode.WS.toString(),
   storeReceiptBeforeStates: true,
-  saveReceiptsWithSignaturePacks: process.env.SAVE_RECEIPTS_WITH_SIGNATURE_PACKS !== undefined ? Boolean(process.env.SAVE_RECEIPTS_WITH_SIGNATURE_PACKS) : true,
+  saveReceiptsWithSignaturePacks:
+    process.env.SAVE_RECEIPTS_WITH_SIGNATURE_PACKS !== undefined
+      ? process.env.SAVE_RECEIPTS_WITH_SIGNATURE_PACKS === 'true'
+      : true,
   checkpointWindow: 21,
   chainId: process.env.CHAIN_ID || '8082',
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -139,10 +139,7 @@ let config: Config = {
   saveAccountHistoryState: true,
   collectorMode: process.env.COLLECTOR_MODE || collectorMode.WS.toString(),
   storeReceiptBeforeStates: true,
-  saveReceiptsWithSignaturePacks:
-    process.env.SAVE_RECEIPTS_WITH_SIGNATURE_PACKS !== undefined
-      ? process.env.SAVE_RECEIPTS_WITH_SIGNATURE_PACKS === 'true'
-      : true,
+  saveReceiptsWithSignaturePacks: true,
   checkpointWindow: 21,
   chainId: process.env.CHAIN_ID || '8082',
 }

--- a/src/storage/receipt.ts
+++ b/src/storage/receipt.ts
@@ -84,6 +84,12 @@ export async function processReceiptData(receipts: Receipt[], saveOnlyNewData = 
       ...receiptObj,
       beforeStates: config.storeReceiptBeforeStates ? receiptObj.beforeStates : [],
     }
+    
+    if (!config.saveReceiptsWithSignaturePacks && modifiedReceiptObj.signedReceipt) {
+      const signedReceiptCopy = { ...modifiedReceiptObj.signedReceipt }
+      signedReceiptCopy.signaturePack = []
+      modifiedReceiptObj.signedReceipt = signedReceiptCopy
+    }
     if (saveOnlyNewData) {
       const receiptExist = await queryReceiptByReceiptId(tx.txId)
       if (!receiptExist) combineReceipts.push(modifiedReceiptObj as unknown as Receipt)


### PR DESCRIPTION
### **User description**
…packs


___

### **PR Type**
enhancement


___

### **Description**
- Add `saveReceiptsWithSignaturePacks` config flag for receipt storage

- Conditionally exclude signature packs from saved receipts

- Update config interface and default values for new flag


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Add and initialize saveReceiptsWithSignaturePacks config flag</code></dd></summary>
<hr>

src/config/index.ts

<li>Added <code>saveReceiptsWithSignaturePacks</code> to <code>Config</code> interface<br> <li> Set default and env-based value for new flag in config object


</details>


  </td>
  <td><a href="https://github.com/shardeum/collector/pull/90/files#diff-198a1431d7c5e26ea78bc6e54b34b54e6f8ab342dd48ea11013877e8466a87c5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>receipt.ts</strong><dd><code>Conditionally exclude signature packs from saved receipts</code></dd></summary>
<hr>

src/storage/receipt.ts

<li>Conditionally remove <code>signaturePack</code> from <code>signedReceipt</code> when saving <br>receipts<br> <li> Use new config flag to determine if signature packs are included


</details>


  </td>
  <td><a href="https://github.com/shardeum/collector/pull/90/files#diff-927f54ce067fd718e88e30c5f17a74a8e37a8fc863f104eab03a18cecaa77f0c">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>